### PR TITLE
Enable symbol analysis in structs/classes

### DIFF
--- a/src/d1to2fix/symbolsearch.d
+++ b/src/d1to2fix/symbolsearch.d
@@ -58,10 +58,10 @@ public void initializeModuleCache(string[] paths)
             // them for now and only checking modules/packages:
 
             if (   symbol.kind == CompletionKind.moduleName
-                || symbol.kind == CompletionKind.packageName)
-             // || symbol.kind == CompletionKind.structName
-             // || symbol.kind == CompletionKind.interfaceName
-             // || symbol.kind == CompletionKind.className)
+                || symbol.kind == CompletionKind.packageName
+                || symbol.kind == CompletionKind.structName
+                || symbol.kind == CompletionKind.interfaceName
+                || symbol.kind == CompletionKind.className)
             {
                 collectNames((*symbol)[]);
             }

--- a/src/d1to2fix/visitor.d
+++ b/src/d1to2fix/visitor.d
@@ -200,13 +200,15 @@ public final class TokenMappingVisitor : ASTVisitor
         // have unique names.
         else if (type.type2.symbol !is null)
         {
-            import std.range : join;
+            import std.array;
             import std.algorithm : map;
 
-            auto name =
-                type.type2.symbol.identifierOrTemplateChain.identifiersOrTemplateInstances
-                .map!(x => x.identifier.text)
-                .join(".");
+            // use unqualified symbol name for lookup - our delegate names are
+            // usually uniquely named and dsymbol is not well-suited for task
+            // of finding fully qualified names
+
+            auto name = type.type2.symbol.identifierOrTemplateChain
+                .identifiersOrTemplateInstances[$-1].identifier.text;
 
             import d1to2fix.symbolsearch;
             import dsymbol.symbol;

--- a/tests/aliasdg2.d
+++ b/tests/aliasdg2.d
@@ -1,0 +1,6 @@
+struct S
+{
+    alias void delegate ( int ) SomeDg;
+}
+
+void foo ( S.SomeDg dg1, S.SomeDg d2 );

--- a/tests/aliasdg2.d.expected
+++ b/tests/aliasdg2.d.expected
@@ -1,0 +1,6 @@
+struct S
+{
+    alias void delegate ( int ) SomeDg;
+}
+
+void foo ( scope S.SomeDg dg1, scope S.SomeDg d2 );


### PR DESCRIPTION
Will result in more delegate aliases annotated with scope,
including those which aliases are defined inside structs or classes.

Will crash with infinite recursion on ocean before https://github.com/sociomantic/ocean/pull/1402
